### PR TITLE
[Fix]管理者/注文履歴一覧と詳細に関するエラー等

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,12 +13,12 @@
  *= require_tree .
  *= require_self
  */
- 
+
  html,body{
    height: 100%;
    width: 100%;
  }
- 
+
  main{
     background-image: url(background-sample.jpg);
     background-size: cover;
@@ -81,3 +81,8 @@ footer p{
 .table-background {
   background-color: rgba(0,0,0,0.3);
 }
+
+.search{
+  display: flex;
+  justify-content: flex-end;
+  }

--- a/app/controllers/admin/order_details_controller.rb
+++ b/app/controllers/admin/order_details_controller.rb
@@ -4,7 +4,7 @@ class Admin::OrderDetailsController < ApplicationController
     @order_detail.update(order_detail_params)
     @order = Order.find_by(id: @order_detail.order_id)
     @order_details = @order.order_details
-    flash[:success] = "製作ステータスを変更しました"
+    flash[:notice] = "製作ステータスを変更しました"
     if @order_detail.making_status == "making"
        @order.update_attribute(:status, 2)
        redirect_to request.referer

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -3,7 +3,7 @@ class Admin::OrdersController < ApplicationController
 
   def show
     @order = Order.find(params[:id])
-    @customer = Customer.find(params[:id])
+    @customer = Customer.find_by(id: @order.customer_id)
     @order_detail = @order.order_details.find_by(order_id: @order.id)
   end
 
@@ -11,12 +11,11 @@ class Admin::OrdersController < ApplicationController
     @order = Order.find(params[:id])
     @order_details = @order.order_details
     @order.update(order_params)
-    flash[:notice] = "注文ステータスを更新しました"
       if @order.status == "payment_confirm"
          @order_details.update_all("making_status = 1")
-      else
-         redirect_to request.referer
       end
+    flash[:notice] = "注文ステータスを更新しました"
+    redirect_to request.referer
   end
 
   private

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -5,7 +5,10 @@
         <tbody>
           <tr>
             <th>購入者</th>
-            <td><%= link_to @order.name, admin_customer_path(@customer.id) %></td>
+            <td><%= link_to admin_customer_path(@customer.id) do %>
+                  <%= @customer.last_name + " " +  @customer.first_name %>様
+                <% end %>
+            </td>
           </tr>
           <tr>
             <th>注文日</th>
@@ -51,9 +54,9 @@
             <% @order.order_details.all.each do |order_detail| %>
               <tr>
                 <td class="align-middle"><%= order_detail.item.name %></td>
-                <td class="align-middle"><%= (order_detail.item.price).to_s(:delimited) %></td>
+                <td class="align-middle"><%= (order_detail.item.price).to_s(:delimited) %>円</td>
                 <td class="align-middle"><%= order_detail.amount %> 個</td>
-                <td class="align-middle"><%= (order_detail.item.price*order_detail.amount).to_s(:delimited) %></td>
+                <td class="align-middle"><%= (order_detail.item.price*order_detail.amount).to_s(:delimited) %>円</td>
                 <td class="align-middle"><%= form_with model: order_detail, url: admin_order_detail_path(order_detail), method: :patch do |f| %>
                       <%= f.select :making_status, OrderDetail.making_statuses_i18n.invert %>
                       <%= f.submit '更新', class: "btn btn-success ml-2" %>
@@ -68,7 +71,7 @@
         <table class="table table-borderless mx-5">
           <tr>
             <th>商品合計</th>
-            <td><%= (@order.total_payment - @order.shipping_fee).to_s(:delimited) %>円</td>
+            <td><%= @order.total_payment.to_s(:delimited) %>円</td>
           </tr>
           <tr>
             <th>送料</th>
@@ -76,7 +79,7 @@
           </tr>
           <tr>
             <th>請求金額</th>
-            <td><%= @order.total_payment.to_s(:delimited) %>円</td>
+            <td><%= (@order.total_payment + @order.shipping_fee).to_s(:delimited) %>円</td>
           </tr>
         </table>
       </div>

--- a/app/views/layouts/_header_admin.html.erb
+++ b/app/views/layouts/_header_admin.html.erb
@@ -6,25 +6,30 @@
     </button>
     <div class="collapse navbar-collapse" id="navbarNavDropdown">
       <ul class="navbar-nav ml-auto">
-      <% if admin_signed_in? %>
-        <ul class="navbar-nav">
-          <li class="nav-item">
-            <%= link_to admin_items_path, class: "nav-link" do %><i class="fas fa-birthday-cake"></i>商品一覧<% end %>
-          </li>
-          <li class="nav-item">
-            <%= link_to admin_customers_path, class: "nav-link" do %><i class="fas fa-address-book"></i>会員一覧<% end %>
-          </li>
-          <li class="nav-item">
-            <%= link_to admin_root_path, class: "nav-link" do %><i class="fas fa-receipt"></i>注文履歴一覧<% end %>
-          </li>
-          <li class="nav-item">
-            <%= link_to admin_genres_path, class: "nav-link" do %><i class="fas fa-bars"></i>ジャンル一覧<% end %>
-          </li>
-          <li class="nav-item">
-            <%= link_to destroy_admin_session_path, method: :delete, class: "nav-link" do %><i class="fas fa-sign-out-alt"></i>ログアウト<% end %>
-          </li>
-        </ul>
-      <% end %>
+        <div class="menu">
+          <ul class="navbar-nav">
+            <li class="nav-item">
+              <%= link_to admin_items_path, class: "nav-link" do %><i class="fas fa-birthday-cake"></i>商品一覧<% end %>
+            </li>
+            <li class="nav-item">
+              <%= link_to admin_customers_path, class: "nav-link" do %><i class="fas fa-address-book"></i>会員一覧<% end %>
+            </li>
+            <li class="nav-item">
+              <%= link_to admin_root_path, class: "nav-link" do %><i class="fas fa-receipt"></i>注文履歴一覧<% end %>
+            </li>
+            <li class="nav-item">
+              <%= link_to admin_genres_path, class: "nav-link" do %><i class="fas fa-bars"></i>ジャンル一覧<% end %>
+            </li>
+            <li class="nav-item">
+              <%= link_to destroy_admin_session_path, method: :delete, class: "nav-link" do %><i class="fas fa-sign-out-alt"></i>ログアウト<% end %>
+            </li>
+          </ul>
+          <div class="search input-group">
+            <input type="text" class="form-control col-3" placeholder="Search">
+            <button class="btn btn-outline-warning" type="button" id="button-addon2"><i class="fas fa-search"></i></button>
+          </div>
+        </div>
+      </ul>
     </div>
   </div>
 </nav>

--- a/app/views/layouts/_header_customer.html.erb
+++ b/app/views/layouts/_header_customer.html.erb
@@ -6,23 +6,29 @@
     </button>
     <div class="collapse navbar-collapse" id="navbarNavDropdown">
       <ul class="navbar-nav ml-auto">
-      <% if customer_signed_in? %>
-          <div class="pt-2 mr-5">
-            ようこそ、<%= current_customer.last_name + " " + current_customer.first_name %>さん！
+        <div class="my-auto mr-4">
+          ようこそ、<%= current_customer.last_name + " " + current_customer.first_name %>さん！
+        </div>
+        <div class="menu">
+          <ul class="navbar-nav mb-2">
+            <li>
+              <%= link_to customers_mypage_path, class: 'nav-link btn btn-outline-secondary mr-2' do %><i class="fas fa-house-user"></i>マイページ<% end %>
+            </li>
+            <li>
+              <%= link_to items_path, class: 'nav-link btn btn-outline-secondary mr-2' do %><i class="fas fa-birthday-cake"></i>商品一覧<% end %>
+            </li>
+            <li>
+              <%= link_to cart_items_path, class: 'nav-link btn btn-outline-secondary mr-2' do %><i class="fas fa-cart-arrow-down"></i>カート<% end %>
+            </li>
+            <li>
+              <%= link_to destroy_customer_session_path, method: :delete, class: 'nav-link btn btn-outline-secondary' do %><i class="fas fa-sign-out-alt"></i>ログアウト<% end %>
+            </li>
+          </ul>
+          <div class="search input-group">
+            <input type="text" class="form-control col-3" placeholder="Search">
+            <button class="btn btn-outline-warning" type="button" id="button-addon2"><i class="fas fa-search"></i></button>
           </div>
-          <li>
-            <%= link_to customers_mypage_path, class: 'nav-link btn btn-outline-secondary mr-2' do %><i class="fas fa-house-user"></i>マイページ<% end %>
-          </li>
-          <li>
-            <%= link_to items_path, class: 'nav-link btn btn-outline-secondary mr-2' do %><i class="fas fa-birthday-cake"></i>商品一覧<% end %>
-          </li>
-          <li>
-            <%= link_to cart_items_path, class: 'nav-link btn btn-outline-secondary mr-2' do %><i class="fas fa-cart-arrow-down"></i>カート<% end %>
-          </li>
-          <li>
-            <%= link_to destroy_customer_session_path, method: :delete, class: 'nav-link btn btn-outline-secondary' do %><i class="fas fa-sign-out-alt"></i>ログアウト<% end %>
-          </li>
-      <% end %>
+        </div>
       </ul>
     </div>
   </div>

--- a/app/views/layouts/_header_visitor.html.erb
+++ b/app/views/layouts/_header_visitor.html.erb
@@ -6,19 +6,27 @@
     </button>
     <div class="collapse navbar-collapse" id="navbarNavDropdown">
       <ul class="navbar-nav ml-auto">
-          <li>
-            <%= link_to about_path, class: 'nav-link btn btn-outline-secondary mr-2' do %><i class="fas fa-store-alt"></i>about<% end %>
-          </li>
-          <li>
-            <%= link_to items_path, class: 'nav-link btn btn-outline-secondary mr-2' do %><i class="fas fa-birthday-cake"></i>商品一覧<% end %>
-          </li>
-          <li>
-            <%= link_to new_customer_registration_path, class: 'nav-link btn btn-outline-secondary mr-2' do %><i class="fas fa-user-plus"></i>新規登録<% end %>
-          </li>
-          <li>
-            <%= link_to new_customer_session_path, class: 'nav-link btn btn-outline-secondary' do %><i class="fas fa-sign-in-alt"></i>ログイン<% end %>
-          </li>
-     </ul>
+        <div class="menu">
+          <ul class="navbar-nav mb-2">
+            <li class="nav-item">
+              <%= link_to about_path, class: 'nav-link btn btn-outline-secondary mr-2' do %><i class="fas fa-store-alt"></i>about<% end %>
+            </li>
+            <li class="nav-item">
+              <%= link_to items_path, class: 'nav-link btn btn-outline-secondary mr-2' do %><i class="fas fa-birthday-cake"></i>商品一覧<% end %>
+            </li>
+            <li class="nav-item">
+              <%= link_to new_customer_registration_path, class: 'nav-link btn btn-outline-secondary mr-2' do %><i class="fas fa-user-plus"></i>新規登録<% end %>
+            </li>
+            <li class="nav-item">
+              <%= link_to new_customer_session_path, class: 'nav-link btn btn-outline-secondary' do %><i class="fas fa-sign-in-alt"></i>ログイン<% end %>
+            </li>
+          </ul>
+          <div class="search input-group">
+            <input type="text" class="form-control col-3" placeholder="Search">
+            <button class="btn btn-outline-warning" type="button" id="button-addon2"><i class="fas fa-search"></i></button>
+          </div>
+        </div>
+      </ul>
     </div>
   </div>
 </nav>

--- a/app/views/public/orders/index.html.erb
+++ b/app/views/public/orders/index.html.erb
@@ -27,7 +27,7 @@
                 <%= order_detail.item.name %></br>
               <% end %>
             </td>
-            <td>￥<%= (order.total_payment + order.shipping_fee).to_s(:delimited) %></td>
+            <td><%= (order.total_payment + order.shipping_fee).to_s(:delimited) %>円</td>
             <td><%= order.status_i18n %></td>
             <td><%= link_to "表示する", order_path(order.id), class:"btn btn-primary" %></td>
           </tr>

--- a/app/views/public/orders/show.html.erb
+++ b/app/views/public/orders/show.html.erb
@@ -36,15 +36,15 @@
           <tbody>
             <tr>
               <th class="table-danger">商品合計</th>
-              <td class="table-warning">￥<%= (@order.total_payment).to_s(:delimited) %></td>
+              <td class="table-warning"><%= (@order.total_payment).to_s(:delimited) %>円</td>
             </tr>
             <tr>
               <th class="table-danger">配送料</th>
-              <td class="table-warning">￥<%= @order.shipping_fee %></td>
+              <td class="table-warning"><%= @order.shipping_fee %>円</td>
             </tr>
             <tr>
               <th class="table-danger">ご請求額</th>
-              <td class="table-warning">￥<%= (@order.total_payment + @order.shipping_fee).to_s(:delimited) %></td>
+              <td class="table-warning"><%= (@order.total_payment + @order.shipping_fee).to_s(:delimited) %>円</td>
             </tr>
           <tbody>
         </table>
@@ -66,9 +66,9 @@
         <% @order.order_details.all.each do |order_detail| %>
         <tr class="table-warning">
           <td><%= order_detail.item.name %></td>
-          <td>￥<%= order_detail.item.with_tax_price.to_s(:delimited) %></td>
+          <td><%= order_detail.item.with_tax_price.to_s(:delimited) %>円</td>
           <td><%= order_detail.amount%> 個</td>
-          <td>￥<%= (order_detail.item.with_tax_price*order_detail.amount).to_s(:delimited)  %></td>
+          <td><%= (order_detail.item.with_tax_price*order_detail.amount).to_s(:delimited) %>円</td>
         </tr>
         <% end %>
       </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ end
 
  root to: 'public/homes#top'
  get 'about' =>'public/homes#about'
+ get "search" => "public/searches#search"
 
  scope module: :public do
  resources :addresses


### PR DESCRIPTION
【実施内容】
・管理者/注文履歴一覧と詳細での購入者名や金額が違う不具合の修正
・注文履歴詳細に行こうとすると「customer_id =[3]」などのエラーが出る不具合の修正
・会員/注文履歴詳細の表記ミスの修正
・ヘッダーに検索窓を付けました（検索機能自体はありません）